### PR TITLE
chore: add commitlint action config

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,15 @@
+const Configuration = {
+  /*
+   * Resolve and load @commitlint/config-conventional from node_modules.
+   * Referenced packages must be installed
+   */
+  extends: ['@commitlint/config-conventional'],
+  /*
+   * Any rules defined here will override rules from @commitlint/config-conventional
+   */
+  rules: {
+    'body-max-line-length': [1, 'always', 80],
+  },
+};
+
+module.exports = Configuration;


### PR DESCRIPTION
This allows dependabot PRs to pass commitlint when they are wider than
strictly necessary.