### PR TITLE
chore: disable codeql schedule

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -7,8 +7,6 @@ on:
   pull_request:
     branches:
     - main
-  schedule:
-  - cron: '44 10 * * 5'
 
 jobs:
   analyze:


### PR DESCRIPTION
With the schedule enabled, Github will spam you repeatedly if nothing is
merged to main for a few weeks.