### PR TITLE
chore: move the version variables into version.go

### DIFF
--- a/cmd/go-cli-github/main.go
+++ b/cmd/go-cli-github/main.go
@@ -4,14 +4,6 @@ import (
 	"github.com/alecthomas/kong"
 )
 
-var (
-	commit      string
-	date        string
-	goVersion   string
-	projectName string
-	version     string
-)
-
 // CLI represents the command-line interface.
 type CLI struct {
 	Version VersionCmd `kong:"cmd,help='Print version information'"`

--- a/cmd/go-cli-github/version.go
+++ b/cmd/go-cli-github/version.go
@@ -5,6 +5,15 @@ import (
 	"fmt"
 )
 
+// These variables are set by GoReleaser during the build.
+var (
+	commit      string
+	date        string
+	goVersion   string
+	projectName string
+	version     string
+)
+
 // VersionCmd represents the `version` command.
 type VersionCmd struct{}
 


### PR DESCRIPTION
These variables are only used in this file, so they should be declared there too.