### PR TITLE
fix: use the new syntax for output variables in github actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,8 +32,8 @@ jobs:
         if [ -z $(git tag -l $(ccv)) ]; then
           git tag $(ccv)
           git push --tags
-          echo "::set-output name=new::true"
-          echo "::set-output name=new_tag_version::$(git tag --points-at HEAD)"
+          echo "new=true" >> $GITHUB_OUTPUT
+          echo "new_tag_version=$(git tag --points-at HEAD)" >> $GITHUB_OUTPUT
         fi
   release:
     needs: tag


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/