### PR TITLE
chore: add explicit build ID

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,4 +49,4 @@ jobs:
         labels: ${{ steps.docker_metadata.outputs.labels }}
         file: Dockerfile
         build-args: BINARY=${{ matrix.binary }}
-        context: dist/${{ env.GITHUB_REPOSITORY_NAME }}_linux_amd64_v1
+        context: dist/${{ matrix.binary }}_linux_amd64_v1

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,6 +1,7 @@
 builds:
-- main: ./cmd/go-cli-github
+- id: go-cli-github
   binary: go-cli-github
+  main: ./cmd/go-cli-github
   ldflags:
   - >
     -s -w


### PR DESCRIPTION
Despite the suggestion in the docs, the build ID does not default to the value of the "binary" field.