### PR TITLE
chore: avoid lint by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # local development targets
 
 .PHONY: test
-test: mod-tidy generate lint
+test: mod-tidy generate
 	go test -v ./...
 
 .PHONY: mod-tidy


### PR DESCRIPTION
This enables make to run properly in CodeQL by default.
