### PR TITLE
feat: update dependabot configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,24 +3,33 @@ updates:
 - package-ecosystem: github-actions
   directory: /
   schedule:
-    interval: weekly
+    interval: monthly
   groups:
     github-actions:
       patterns:
       - "*"
+      update-types:
+      - "minor"
+      - "patch"
 - package-ecosystem: docker
   directory: /
   schedule:
-    interval: daily
+    interval: monthly
   groups:
     docker:
       patterns:
       - "*"
+      update-types:
+      - "minor"
+      - "patch"
 - package-ecosystem: gomod
   directory: /
   schedule:
-    interval: daily
+    interval: monthly
   groups:
     gomod:
       patterns:
       - "*"
+      update-types:
+      - "minor"
+      - "patch"


### PR DESCRIPTION
* change the dependabot version update interval to monthly
* only group patch and minor version updates.
  major versions get their own PR for ease of tracking changes.
