### PR TITLE
feat: simplify mock handling

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -16,9 +16,7 @@ jobs:
         go-version: stable
     - name: Calculate coverage
       run: |
-        go test -v -covermode=atomic -coverprofile=cover.out.raw -coverpkg=./... ./...
-        # remove generated code from coverage calculation
-        grep -Ev 'internal/mock|_enumer.go' cover.out.raw > cover.out
+        go test -v -covermode=atomic -coverprofile=cover.out -coverpkg=./... ./...
     - name: Generage coverage badge
       uses: vladopajic/go-test-coverage@c7fe52e0f48e0fbed8c1812824c5346218443c70 # v2.10.2
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /dist
 /cover.out
-/cover.out.raw
 /sbom.spdx.json

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,5 @@ fuzz: mod-tidy generate
 
 .PHONY: cover
 cover: mod-tidy generate
-	go test -v -covermode=atomic -coverprofile=cover.out.raw -coverpkg=./... ./...
-	grep -Ev 'internal/mock|_enumer.go' cover.out.raw > cover.out
+	go test -v -covermode=atomic -coverprofile=cover.out -coverpkg=./... ./...
 	go tool cover -html=cover.out


### PR DESCRIPTION
mockgen generated mocks are now expected to be:

* in the same directory as the _test.go files
* suffixed _mock_test.go, so they are handled correctly by the go
  tooling (ignored during build, coverage calculation etc.)
* in the same package as the _test.go files
