### PR TITLE
fix: use the GitHub REST API for SBOM

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,14 +44,13 @@ jobs:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - uses: advanced-security/sbom-generator-action@6fe43abf522b2e7a19bc769aec1e6c848614b517 # v0.0.2
-      id: sbom
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Move sbom to avoid dirty git
-      run: mv "$GITHUB_SBOM_PATH" ./sbom.spdx.json
-      env:
-        GITHUB_SBOM_PATH: ${{ steps.sbom.outputs.fileName }}
+    - name: Export SBOM in SPDX JSON format
+      # https://docs.github.com/en/rest/dependency-graph/sboms?apiVersion=2022-11-28
+      run: |
+        gh api \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          /repos/${{ github.repository }}/dependency-graph/sbom > sbom.spdx.json
     - uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
       id: goreleaser
       with:


### PR DESCRIPTION
Since the SBOM action is now deprecated, remove it and instead use the
recommended REST API via the gh CLI.
