### PR TITLE
chore: add default exclusions for golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,5 @@
+version: "2"
+linters:
+  exclusions:
+    presets:
+    - std-error-handling


### PR DESCRIPTION
This config vastly improves the signal to noise ratio from the linter.

https://golangci-lint.run/usage/false-positives/#preset-std-error-handling
