### PR TITLE
chore: re-order syft installation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,6 +38,7 @@ jobs:
     - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: stable
+    - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
     # The setup-buildx-action enables the docker-container driver, which allows
     # SBOM generation for the resulting container image using the syft
     # container which is automatically pulled and run during the container
@@ -46,7 +47,6 @@ jobs:
     # in .goreleaser.yaml), it also needs to install syft into the action
     # environment.
     - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-    - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
     - name: Login to GHCR
       uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       with:


### PR DESCRIPTION
This makes it easier to remove the image build steps in a block.
